### PR TITLE
Remove redundant configurability

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ This a bit similar gem to (angular-rails-templates)[https://github.com/pitr/angu
 app/views/some/ui/show.html.erb:
 
     <%= ng_template_include 'some/path' %>
+
+    OR
+
+    <%= ng_template_include 'some/path', prefix: '_some_prefix_' %>

--- a/app/helpers/ng_template/template_helper.rb
+++ b/app/helpers/ng_template/template_helper.rb
@@ -13,8 +13,7 @@ module TemplateHelper
       @view_ctx = view_ctx
       @paths = Array(paths)
       @opt = {
-        mode: Rails.configuration.ng_template.mode,
-        prefix: Rails.configuration.ng_template.prefix,
+        prefix: '_ng_',
       }.merge!(opt)
     end
 
@@ -46,8 +45,9 @@ module TemplateHelper
       Dir["#{view_path}/#{path}/#{@opt[:prefix]}*.html*"].map do |file_path|
         name = File.basename(file_path)
         partial_name = path + "/" + name[1, name.index('.') - 1]
+        template_name = path + "/" + name[@opt[:prefix].length..(name.index('.') - 1)]
         {
-          name: partial_name,
+          name: template_name,
           content: render_template(partial_name),
         }
       end
@@ -63,10 +63,10 @@ module TemplateHelper
   end
 
   #
-  # Render all templates in given path
+  # Render all templates in given path as HTML
   #
-  def ng_template_include(paths)
-    TemplateRenderer.new(self, paths).render
+  def ng_template_include(paths, opt = {})
+    TemplateRenderer.new(self, paths, opt).render
   end
 end
 end

--- a/lib/ng_template/engine.rb
+++ b/lib/ng_template/engine.rb
@@ -1,11 +1,5 @@
 module NgTemplate
   class Engine < ::Rails::Engine
     isolate_namespace NgTemplate
-
-    initializer 'ng_template init' do
-      config.ng_template = ActiveSupport::OrderedOptions.new
-      config.ng_template.mode = :html
-      config.ng_template.prefix = '_'
-    end
   end
 end


### PR DESCRIPTION
- FIX removed "mode" as redundant
- FIX removed global configurability
  - poses trouble with multiple engine gems
- FIX changed default pfefix to be distinct from rails partials
  - allow using rails partials within ng templates
